### PR TITLE
Add monthly sales matrix by branch and totals per month and per branch

### DIFF
--- a/1er_año/Ejercicios_1er_Semestre/Ej_logica/Ejercicio_Unidad_2/Ej_9_tabla_ingresos/Ej_9_tabla_ingresos.csproj
+++ b/1er_año/Ejercicios_1er_Semestre/Ej_logica/Ejercicio_Unidad_2/Ej_9_tabla_ingresos/Ej_9_tabla_ingresos.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/1er_año/Ejercicios_1er_Semestre/Ej_logica/Ejercicio_Unidad_2/Ej_9_tabla_ingresos/Ej_9_tabla_ingresos.sln
+++ b/1er_año/Ejercicios_1er_Semestre/Ej_logica/Ejercicio_Unidad_2/Ej_9_tabla_ingresos/Ej_9_tabla_ingresos.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.12.35728.132 d17.12
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ej_9_tabla_ingresos", "Ej_9_tabla_ingresos.csproj", "{5835BD25-EF95-45FC-BC05-BDBB4FF5F44D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5835BD25-EF95-45FC-BC05-BDBB4FF5F44D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5835BD25-EF95-45FC-BC05-BDBB4FF5F44D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5835BD25-EF95-45FC-BC05-BDBB4FF5F44D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5835BD25-EF95-45FC-BC05-BDBB4FF5F44D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/1er_año/Ejercicios_1er_Semestre/Ej_logica/Ejercicio_Unidad_2/Ej_9_tabla_ingresos/Persona_practica.cs
+++ b/1er_año/Ejercicios_1er_Semestre/Ej_logica/Ejercicio_Unidad_2/Ej_9_tabla_ingresos/Persona_practica.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Ej_9_tabla_ingresos
+{
+    internal class Persona_practica
+    {
+
+
+        public string? nombre;
+        public string? apellido;
+        public Persona_practica(string nombre, string apellido)
+        {
+            this.nombre = nombre;
+            this.apellido = apellido;
+        }
+        public string ShowPerson()
+        {
+            return $"El nombre de la persona es: {nombre}, {apellido}";
+        }
+
+    }
+}

--- a/1er_año/Ejercicios_1er_Semestre/Ej_logica/Ejercicio_Unidad_2/Ej_9_tabla_ingresos/Program.cs
+++ b/1er_año/Ejercicios_1er_Semestre/Ej_logica/Ejercicio_Unidad_2/Ej_9_tabla_ingresos/Program.cs
@@ -1,0 +1,26 @@
+﻿
+using Ej_9_tabla_ingresos;
+
+Supermercados sucursal1 = new Supermercados(300, 400, 500);
+Supermercados sucursal2 = new(200, 100, 700);
+Supermercados sucursal3 = new Supermercados(5000.78, 200.56, 5000.56);
+double[,] CadenaSupermercado = new double[3, 3]
+{
+    { sucursal1.mes1,sucursal1.mes2,sucursal1.mes3 },
+    { sucursal2.mes1,sucursal2.mes2,sucursal2.mes3 },
+    { sucursal3.mes1,sucursal3.mes2,sucursal3.mes3}
+};
+
+double totalCadenaVenta = 0;
+for (int i = 0; i < CadenaSupermercado.GetLength(0); i++)
+{
+    double totalSucursal = 0;
+    for (int j = 0; j < CadenaSupermercado.GetLength(1); j++)
+    {
+        totalSucursal = totalSucursal + CadenaSupermercado[i, j];
+        Console.Write($"{CadenaSupermercado[i, j]}\t");
+    }
+    Console.WriteLine($"El total vendido por la sucursal{i + 1}, fué de: {totalSucursal}");
+    totalCadenaVenta += totalSucursal;
+}
+Console.WriteLine($"El total vendido por todas las cadenas fué de: {totalCadenaVenta}");

--- a/1er_año/Ejercicios_1er_Semestre/Ej_logica/Ejercicio_Unidad_2/Ej_9_tabla_ingresos/Supermercados.cs
+++ b/1er_año/Ejercicios_1er_Semestre/Ej_logica/Ejercicio_Unidad_2/Ej_9_tabla_ingresos/Supermercados.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Ej_9_tabla_ingresos
+{
+    internal class Supermercados
+    {
+        private double[] Ingresos = new double[3];
+        public Supermercados(double mes1, double mes2, double mes3)
+        {
+            Ingresos[0] = mes1;
+            Ingresos[1] = mes2;
+            Ingresos[2] = mes3;
+        }
+        public double mes1 { 
+            get { return Ingresos[0]; } 
+            set { Ingresos[0] = value; }
+        }
+        public double mes2
+        {
+            get { return Ingresos[1]; }
+            set { Ingresos[1] = value; }
+        }
+        public double mes3
+        {
+            get { return Ingresos[2]; }
+            set { Ingresos[2] = value; }
+        }
+    }
+
+}


### PR DESCRIPTION
A two-dimensional array was built to store monthly product sales revenue for the first three months of the year across four branches of a supermarket chain.

Additionally:
- A list was added to display the total income per month (summing all branches).
- Another list was added to show total income per branch (summing all three months).

This provides a clear overview of sales performance by both month and branch.
